### PR TITLE
Modifying the references from arXiv to Spring Nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ https://zenodo.org/record/7950602
 If you use this pipeline, please cite:
 
 ```
-Etienne St-Onge, Kurt Schilling, Francois Rheault, "BundleSeg: A versatile,
-reliable and reproducible approach to white matter bundle segmentation.",
-arXiv, 2308.10958 (2023)
+St-Onge, Etienne, Kurt G. Schilling, and Francois Rheault. "BundleSeg: A versatile, 
+reliable and reproducible approach to white matter bundle segmentation." International 
+Workshop on Computational Diffusion MRI. Cham: Springer Nature Switzerland, (2023)
 
 Rheault, Francois. Analyse et reconstruction de faisceaux de la matière blanche.
 page 137-170, (2020), https://savoirs.usherbrooke.ca/handle/11143/17255

--- a/USAGE
+++ b/USAGE
@@ -15,9 +15,9 @@ Warning
 Output images in mni space are named "*_mni.nii.gz", if not there are in native space.
 
 If using this pipeline, please read and cite the following publications:
-[1] Etienne St-Onge, Kurt Schilling, Francois Rheault, "BundleSeg: A versatile,
-    reliable and reproducible approach to white matter bundle segmentation.",
-    arXiv, 2308.10958 (2023)
+[1] St-Onge, Etienne, Kurt G. Schilling, and Francois Rheault. "BundleSeg: A versatile, 
+    reliable and reproducible approach to white matter bundle segmentation." International 
+    Workshop on Computational Diffusion MRI. Cham: Springer Nature Switzerland, (2023)
 [2] Rheault, François. "Analyse et reconstruction de faisceaux de la matière
     blanche." Computer Science. Université de Sherbrooke (2020).
 	(Only chapter #4, in French)


### PR DESCRIPTION
Modifying the reference for BundleSeg because the paper was officially published on CDMRI (2023).