### PR TITLE
Fix missing file when copying

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -5,6 +5,7 @@ process {
     stageOutMode = 'rsync'
     tag = { "$sid" }
     afterScript = 'sleep 1'
+    containerOptions = "--user \$(id -u):\$(id -g)"
 }
 
 params {


### PR DESCRIPTION
cp operations (e.g. in the Register_T1 stage) seem to keep the original file permissions which seems to cause some problems on machines where the user doesn't have access to read/write/exectute on some files, preventing nextflow to sync those files in the final nextflow staging process. This PR fixes that issue.